### PR TITLE
add devbox based dependency isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ cython_debug/
 .DS_Store
 .marimo
 test/
+
+.devbox
+# enforcing strict reproducibility not suitable for template
+devbox.lock

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
+  "packages": ["uv@latest", "python@latest"],
+  "shell": {
+    "init_hook": [". $VENV_DIR/bin/activate"],
+    "scripts": {
+      "build": [
+        "uv run build.py --output_dir '_site' --template 'templates/tailwind.html.j2'"
+      ],
+      "serve": ["python -m http.server -d _site"]
+    }
+  }
+}


### PR DESCRIPTION
- dependency isolation using [devbox](https://www.jetify.com/devbox)
- [devbox configuration for Python poetry](https://www.jetify.com/devbox/templates/python-poetry) adapted to `uv`
- setup
  - [Install](https://www.jetify.com/docs/devbox/installing-devbox) devbox for the operating system of choice.
- demo usage
  - `devbox shell`
  - `devbox run build`
  - `devbox run serve`
- usage

```
python NOTES:
Python in Devbox works best when used with a virtual environment (venv, virtualenv, etc.). Devbox will automatically create a virtual environment using `venv` for python3 projects, so you can install packages with pip as normal.
To activate the environment, run `. $VENV_DIR/bin/activate` or add it to the init_hook of your devbox.json
To change where your virtual environment is created, modify the $VENV_DIR environment variable in your init_hook

This plugin creates the following helper files:
* /home/florian/github/marimo-gh-pages-template/.devbox/virtenv/python/bin/venvShellHook.sh

This plugin sets the following environment variables:
* VENV_DIR=/home/florian/github/marimo-gh-pages-template/.venv

To show this information, run `devbox info python`
```


I'm not sure where to put the setup and usage info best into (dedicated readme section?). Proposals are welcome.